### PR TITLE
Remove leading prompt from build commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,13 @@ This page uses the comment format specified by [Remontoire](https://github.com/r
 
 ## Build
 
-Ilia uses `meson` and `ninja` to build.  Example:
+Ilia uses `meson` and `ninja` to build.  
+
+```
+sudo apt install meson ninja-build valac libjson-glib-dev libtracker-sparql-2.0-dev libgee-0.8-dev
+```
+
+Example:
 
 ```
 git clone https://github.com/regolith-linux/ilia.git

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ This page uses the comment format specified by [Remontoire](https://github.com/r
 Ilia uses `meson` and `ninja` to build.  Example:
 
 ```
-$ git clone https://github.com/regolith-linux/ilia.git
-$ mkdir ilia/build
-$ cd ilia/build
-$ meson ..
-$ ninja
-$ src/ilia
+git clone https://github.com/regolith-linux/ilia.git
+mkdir ilia/build
+cd ilia/build
+meson ..
+ninja
+src/ilia
 ```
 
 ## Package

--- a/README.md
+++ b/README.md
@@ -47,9 +47,13 @@ This page uses the comment format specified by [Remontoire](https://github.com/r
 Ilia uses `meson` and `ninja` to build.  
 
 ```
-sudo apt install meson ninja-build valac libjson-glib-dev libtracker-sparql-2.0-dev libgee-0.8-dev
+sudo apt install ninja-build valac libjson-glib-dev libtracker-sparql-2.0-dev libgee-0.8-dev
 ```
+meson needs to be installed with pip for some reason
 
+```
+sudo pip3 install meson
+```
 Example:
 
 ```


### PR DESCRIPTION
The leading `$` make copying the commands to the terminal cumbersome.