### PR TITLE
App load optimization

### DIFF
--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -71,11 +71,11 @@ namespace Ilia {
             var focus_page = arg_map.get ("-p") ?? "Apps";
             bool all_page_mode = arg_map.contains("-a");
 
-            stdout.printf("init_pages: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("init_pages: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
 
             init_pages (arg_map, focus_page, all_page_mode);
 
-            stdout.printf("grid: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("grid: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
 
             grid = new Gtk.Grid ();
             grid.get_style_context ().add_class ("root_box");
@@ -156,7 +156,7 @@ namespace Ilia {
             });
 
             entry.activate.connect (on_entry_activated);
-            stdout.printf("ialog_pages[active_page].show (): %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("ialog_pages[active_page].show (): %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
             dialog_pages[active_page].show (); // Get page ready to use
         }
 
@@ -204,7 +204,7 @@ namespace Ilia {
                 box.pack_start (label, false, false, 5);
                 box.show_all ();
                 notebook.append_page (dialog_pages[i].get_root (), box);
-                stdout.printf("append_page %d: %" + int64.FORMAT + "\n", i, (get_monotonic_time() - start_time));
+                // stdout.printf("append_page %d: %" + int64.FORMAT + "\n", i, (get_monotonic_time() - start_time));
             }
 
             // FIXME - rework help UI to be consistent for both single and all page modes

--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -71,7 +71,11 @@ namespace Ilia {
             var focus_page = arg_map.get ("-p") ?? "Apps";
             bool all_page_mode = arg_map.contains("-a");
 
+            stdout.printf("init_pages: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+
             init_pages (arg_map, focus_page, all_page_mode);
+
+            stdout.printf("grid: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
 
             grid = new Gtk.Grid ();
             grid.get_style_context ().add_class ("root_box");
@@ -152,7 +156,7 @@ namespace Ilia {
             });
 
             entry.activate.connect (on_entry_activated);
-
+            stdout.printf("ialog_pages[active_page].show (): %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
             dialog_pages[active_page].show (); // Get page ready to use
         }
 
@@ -200,6 +204,7 @@ namespace Ilia {
                 box.pack_start (label, false, false, 5);
                 box.show_all ();
                 notebook.append_page (dialog_pages[i].get_root (), box);
+                stdout.printf("append_page %d: %" + int64.FORMAT + "\n", i, (get_monotonic_time() - start_time));
             }
 
             // FIXME - rework help UI to be consistent for both single and all page modes

--- a/src/IconLoader.vala
+++ b/src/IconLoader.vala
@@ -32,10 +32,9 @@ namespace Ilia {
 
                 if (GLib.File.new_for_path (icon_name).query_exists ()) {
                     try {
-                        stdout.printf("new_for_path\n");
                         return new Gdk.Pixbuf.from_file_at_size (icon_name, size, size);
                     } catch (Error e) {
-                        stderr.printf ("1Error loading icon: %s\n", e.message);
+                        stderr.printf ("Error loading icon: %s\n", e.message);
                     }
                 }
             }

--- a/src/IconLoader.vala
+++ b/src/IconLoader.vala
@@ -25,13 +25,14 @@ namespace Ilia {
             if (icon != null) {
                 icon_name = icon.to_string ();
 
-                var icon_info = icon_theme.lookup_icon (icon_name, size, Gtk.IconLookupFlags.FORCE_SIZE); // from icon theme
+                var icon_info = icon_theme.lookup_icon (icon_name, size, Gtk.IconLookupFlags.FORCE_REGULAR); // from icon theme
                 if (icon_info != null) {
                     return icon_info.load_icon ();
                 }
 
                 if (GLib.File.new_for_path (icon_name).query_exists ()) {
                     try {
+                        stdout.printf("new_for_path\n");
                         return new Gdk.Pixbuf.from_file_at_size (icon_name, size, size);
                     } catch (Error e) {
                         stderr.printf ("1Error loading icon: %s\n", e.message);

--- a/src/IconLoader.vala
+++ b/src/IconLoader.vala
@@ -25,7 +25,7 @@ namespace Ilia {
             if (icon != null) {
                 icon_name = icon.to_string ();
 
-                var icon_info = icon_theme.lookup_icon (icon_name, size, Gtk.IconLookupFlags.FORCE_REGULAR); // from icon theme
+                var icon_info = icon_theme.lookup_icon (icon_name, size, Gtk.IconLookupFlags.FORCE_SIZE); // from icon theme
                 if (icon_info != null) {
                     return icon_info.load_icon ();
                 }

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -4,6 +4,7 @@ using GtkLayerShell;
 // Globals
 bool IS_SESSION_WAYLAND;
 string WM_NAME;
+int64 start_time = 0;
 // Default style
 char* default_css = """
                 .root_box {
@@ -34,6 +35,7 @@ char* default_css = """
  * Application entry point
  */
 public static int main (string[] args) {
+    start_time = get_monotonic_time();
     Gtk.init (ref args);
 
     // Get session type (wayland or x11) and set the flag
@@ -57,7 +59,9 @@ public static int main (string[] args) {
     if (arg_map.contains ("-h") || arg_map.contains ("--help")) print_help_and_exit ();
     if (arg_map.contains ("-v") || arg_map.contains ("--version")) print_version_and_exit ();
 
+    stdout.printf("Ilia.DialogWindow: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
     var window = new Ilia.DialogWindow (arg_map);
+    stdout.printf("window.destroy.connect: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
     window.destroy.connect (Gtk.main_quit);
 
     // Grab inputs from wayland backend before showing window
@@ -68,6 +72,7 @@ public static int main (string[] args) {
     }
 
     initialize_style (window, arg_map);
+    stdout.printf("window.show_all: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
     window.show_all ();
 
     // Grab inputs from X11 backend after showing window

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -35,7 +35,7 @@ char* default_css = """
  * Application entry point
  */
 public static int main (string[] args) {
-    start_time = get_monotonic_time();
+    // start_time = get_monotonic_time();
     Gtk.init (ref args);
 
     // Get session type (wayland or x11) and set the flag

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -4,7 +4,7 @@ using GtkLayerShell;
 // Globals
 bool IS_SESSION_WAYLAND;
 string WM_NAME;
-int64 start_time = 0;
+// int64 start_time = 0;
 // Default style
 char* default_css = """
                 .root_box {

--- a/src/Main.vala
+++ b/src/Main.vala
@@ -59,9 +59,9 @@ public static int main (string[] args) {
     if (arg_map.contains ("-h") || arg_map.contains ("--help")) print_help_and_exit ();
     if (arg_map.contains ("-v") || arg_map.contains ("--version")) print_version_and_exit ();
 
-    stdout.printf("Ilia.DialogWindow: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+    // stdout.printf("Ilia.DialogWindow: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
     var window = new Ilia.DialogWindow (arg_map);
-    stdout.printf("window.destroy.connect: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+    // stdout.printf("window.destroy.connect: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
     window.destroy.connect (Gtk.main_quit);
 
     // Grab inputs from wayland backend before showing window
@@ -72,7 +72,7 @@ public static int main (string[] args) {
     }
 
     initialize_style (window, arg_map);
-    stdout.printf("window.show_all: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+    // stdout.printf("window.show_all: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
     window.show_all ();
 
     // Grab inputs from X11 backend after showing window

--- a/src/apps/DesktopAppPage.vala
+++ b/src/apps/DesktopAppPage.vala
@@ -152,13 +152,6 @@ namespace Ilia {
             // Create columns
             if (icon_size > 0) {
                 item_view.insert_column_with_attributes (-1, "Icon", new CellRendererPixbuf (), "pixbuf", ITEM_VIEW_COLUMN_ICON);
-                /*
-                TreeViewColumn? column = item_view.get_column(0);
-
-                if (column != null) {
-                    column.set_fixed_width (icon_size);
-                }
-                 */
             }
             item_view.insert_column_with_attributes (-1, "Name", new CellRendererText (), "text", ITEM_VIEW_COLUMN_NAME);
 
@@ -269,17 +262,17 @@ namespace Ilia {
         private void load_apps () {
             // var start_time = get_monotonic_time();
             // determine theme for icons
-            stdout.printf("load_apps start: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("load_apps start: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
             icon_theme = Gtk.IconTheme.get_default ();
 
             var app_list = AppInfo.get_all ();
-            Gdk.Pixbuf icon_img = new Gdk.Pixbuf (Gdk.Colorspace.RGB, false, 8, icon_size, icon_size); // Ilia.load_icon_from_name (icon_theme, "applications-other", icon_size);
+            Gdk.Pixbuf blank_icon = new Gdk.Pixbuf (Gdk.Colorspace.RGB, false, 8, icon_size, icon_size); // Ilia.load_icon_from_name (icon_theme, "applications-other", icon_size);
 
-            stdout.printf("load_apps itrate: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("load_apps itrate: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
             foreach (AppInfo appinfo in app_list) {
-                read_desktop_file(appinfo, icon_img);
+                read_desktop_file(appinfo, blank_icon);
             }
-            stdout.printf("load_apps done: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("load_apps done: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
         }
 
         private void read_desktop_file (AppInfo appInfo, Gdk.Pixbuf? default_icon) {
@@ -290,23 +283,8 @@ namespace Ilia {
                 model.append (out iter);
 
                 var keywords = app_info.get_string ("Comment") + app_info.get_string ("Keywords");                
-
-                /*
-                if (icon_size > 0) {
-                    Gdk.Pixbuf icon_img = null;
-                    stdout.printf("read_desktop_file before icon %s: %" + int64.FORMAT + "\n", appInfo.get_name (), (get_monotonic_time() - start_time));
-                    icon_img = Ilia.load_icon_from_info (icon_theme, app_info, icon_size);
-                    stdout.printf("read_desktop_file after  icon %s: %" + int64.FORMAT + "\n",appInfo.get_name (),  (get_monotonic_time() - start_time));
-
-                    model.set (
-                        iter,
-                        ITEM_VIEW_COLUMN_ICON, icon_img,
-                        ITEM_VIEW_COLUMN_NAME, app_info.get_name (),
-                        ITEM_VIEW_COLUMN_KEYWORDS, keywords,
-                        ITEM_VIEW_COLUMN_APPINFO, app_info
-                    );
-                } else { */
-                    // Gdk.Pixbuf icon_img = Ilia.load_icon_from_name (icon_theme, "applications-other", icon_size);
+                
+                if (icon_size > 0) {                    
                     model.set (
                         iter,
                         ITEM_VIEW_COLUMN_ICON, default_icon,
@@ -314,31 +292,33 @@ namespace Ilia {
                         ITEM_VIEW_COLUMN_KEYWORDS, keywords,
                         ITEM_VIEW_COLUMN_APPINFO, app_info
                     );
-                //}
+                } else {
+                    model.set (
+                        iter,
+                        ITEM_VIEW_COLUMN_NAME, app_info.get_name (),
+                        ITEM_VIEW_COLUMN_KEYWORDS, keywords,
+                        ITEM_VIEW_COLUMN_APPINFO, app_info
+                    );
+                }
             }
         }
 
         void loadAppIcons() {
-            stdout.printf("loadAppIcons start: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("loadAppIcons start: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
             TreeIter app_iter;
+            Value app_info_val;
 
-            for (bool next = model.get_iter_first (out app_iter); next; next = model.iter_next (ref app_iter)) {
-                Value app_info_val;
-
+            for (bool next = model.get_iter_first (out app_iter); next; next = model.iter_next (ref app_iter)) {                
                 model.get_value(app_iter, ITEM_VIEW_COLUMN_APPINFO, out app_info_val);
 
-                DesktopAppInfo desktop_ap_info = new DesktopAppInfo (((AppInfo) app_info_val).get_id ());
-
-                Gdk.Pixbuf icon_img = Ilia.load_icon_from_info (icon_theme, desktop_ap_info, icon_size);
+                Gdk.Pixbuf blank_icon = Ilia.load_icon_from_info (icon_theme, (DesktopAppInfo) app_info_val, icon_size);
 
                 model.set (
                     app_iter,
-                    ITEM_VIEW_COLUMN_ICON, icon_img
+                    ITEM_VIEW_COLUMN_ICON, blank_icon
                 );                
             }
-            filter.refilter();
-            item_view.columns_autosize ();
-            stdout.printf("loadAppIcons end  : %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            // stdout.printf("loadAppIcons end  : %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
         }
 
         // In the case that neither success or failure signals are received, exit after a timeout

--- a/src/apps/DesktopAppPage.vala
+++ b/src/apps/DesktopAppPage.vala
@@ -101,7 +101,7 @@ namespace Ilia {
 
             root_widget = scrolled;
 
-            // Generic parameter is the type of return value
+            // Load app icons in background thread
             iconLoadThread = new Thread<void> ("iconLoadThread", loadAppIcons);
         }
 
@@ -266,6 +266,8 @@ namespace Ilia {
             icon_theme = Gtk.IconTheme.get_default ();
 
             var app_list = AppInfo.get_all ();
+
+            // Set a blank icon to avoid visual jank as real icons are loaded
             Gdk.Pixbuf blank_icon = new Gdk.Pixbuf (Gdk.Colorspace.RGB, false, 8, icon_size, icon_size); // Ilia.load_icon_from_name (icon_theme, "applications-other", icon_size);
 
             // stdout.printf("load_apps itrate: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
@@ -303,6 +305,7 @@ namespace Ilia {
             }
         }
 
+        // Iterate over model and load icons
         void loadAppIcons() {
             // stdout.printf("loadAppIcons start: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
             TreeIter app_iter;
@@ -311,11 +314,11 @@ namespace Ilia {
             for (bool next = model.get_iter_first (out app_iter); next; next = model.iter_next (ref app_iter)) {                
                 model.get_value(app_iter, ITEM_VIEW_COLUMN_APPINFO, out app_info_val);
 
-                Gdk.Pixbuf blank_icon = Ilia.load_icon_from_info (icon_theme, (DesktopAppInfo) app_info_val, icon_size);
+                Gdk.Pixbuf icon = Ilia.load_icon_from_info (icon_theme, (DesktopAppInfo) app_info_val, icon_size);
 
                 model.set (
                     app_iter,
-                    ITEM_VIEW_COLUMN_ICON, blank_icon
+                    ITEM_VIEW_COLUMN_ICON, icon
                 );                
             }
             // stdout.printf("loadAppIcons end  : %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));


### PR DESCRIPTION
This experimental PR loads app icons on a background thread.  In local tests this results in the window rendering in about half the time compared to baseline which synchronously loads all app icons before rendering the window.

My local environment loads the dialog so fast that overall this change is a regression (provides no value); there is no _perceptible_ speed increase and now icons can be seen refreshing after the load.  Looking for user feedback to determine if others find value in this change.