### PR TITLE
add missing vim keybinding for navigation

### DIFF
--- a/src/DialogPage.vala
+++ b/src/DialogPage.vala
@@ -70,7 +70,7 @@ namespace Ilia {
         if ((key.state & Gdk.ModifierType.CONTROL_MASK) == Gdk.ModifierType.CONTROL_MASK) { //CTRL
             bool is_last = selection_is_last (item_view.get_selection ());
 
-            if (key.keyval == 'p') {
+            if (key.keyval == 'p' || key.keyval == 'k') {
                 path.prev ();
                 item_view.get_selection ().select_path (path);
                 item_view.set_cursor (path, null, false);

--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -340,6 +340,12 @@ namespace Ilia {
             listmodel.set (iter, 0, "↑ ↓", 1, "Change Selected Item");
 
             listmodel.append (out iter);
+            listmodel.set (iter, 0, "Ctrl+p Ctrl+n", 1, "Change Selected Item (emacs style)");
+
+            listmodel.append (out iter);
+            listmodel.set (iter, 0, "Ctrl+k Ctrl+j", 1, "Change Selected Item (vim style)");
+
+            listmodel.append (out iter);
             listmodel.set (iter, 0, "Esc", 1, "Exit");
         }
 


### PR DESCRIPTION
Greetings!

This implemented feature from this [commit](https://github.com/regolith-linux/ilia/commit/bb5549e28c5018084fa5f569736096c52ea5125ec), which was originated from this [issue](https://github.com/regolith-linux/ilia/issues/10), while it added the emacs going up and down and vim going down, it was missing the "k" for going up for vim. So I added this in this pull request.

I also took the liberty to add the old and new emacs and vim keybindings to the help section.

Here is a gif of what i compiled from the code I changed:

![ilia](https://user-images.githubusercontent.com/22120217/212674887-c082144a-5fe7-4aa9-a673-881d9f44e175.gif)
