### PR TITLE
feat: launch apps and commands using systemd-run

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -251,3 +251,18 @@ string? get_wm_cli() {
     }
     return null;
 }
+
+
+/* Get AppInfo object used to run a command */
+public AppInfo get_runner_app_info (AppInfo app_info) throws GLib.Error {
+    string systemd_run_path = GLib.Environment.find_program_in_path ("systemd-run");
+    if (systemd_run_path == null) {
+      return app_info;
+    }
+    string app_id = app_info.get_id ();
+    string exec = app_info.get_commandline ();
+    string random_suffix = Uuid.string_random ().slice (0, 8);
+    string unit_name = "run_ilia_" + app_id + "_" + random_suffix + ".scope";
+    string systemd_launch = "systemd-run --user --scope --unit "+ unit_name + " " + exec;
+    return AppInfo.create_from_commandline (systemd_launch, app_id, AppInfoCreateFlags.NONE);
+}

--- a/src/apps/DesktopAppPage.vala
+++ b/src/apps/DesktopAppPage.vala
@@ -342,6 +342,7 @@ namespace Ilia {
             filter.@get (selection, ITEM_VIEW_COLUMN_APPINFO, out app_info);
 
             try {
+                AppInfo runner = get_runner_app_info (app_info);
                 AppLaunchContext ctx = new AppLaunchContext();
 
                 ctx.launched.connect ((info, platform_data) => {
@@ -359,7 +360,7 @@ namespace Ilia {
                     // TODO ~ perhaps add some visual hint that launch process has begun
                 });
 
-                var result = app_info.launch (null, ctx);
+                var result = runner.launch (null, ctx);
 
                 if (result) {
                     string key = app_info.get_id ();

--- a/src/commands/CommandPage.vala
+++ b/src/commands/CommandPage.vala
@@ -231,8 +231,9 @@ namespace Ilia {
 
             try {
                 var app_info = AppInfo.create_from_commandline (commandline, null, GLib.AppInfoCreateFlags.NONE);
+                var runner = get_runner_app_info (app_info);
 
-                if (!app_info.launch (null, null)) {
+                if (!runner.launch (null, null)) {
                     stderr.printf ("Error: execute_command failed\n");
                 }
 


### PR DESCRIPTION
# Overview
This change causes ilia to use `systemd-run` to start applications in their own cgroup. This allows specific applications to be killed by `systemd-oomd` instead of the entire session in out-of-memory situations. 

# Why this is important
 Ubuntu has been using `systemd-oomd` to handle out-of-memory situations since v22.04. The [`systemd-oomd` documentation](https://www.freedesktop.org/software/systemd/man/latest/systemd-oomd.service.html#System%20requirements%20and%20configuration) recommends starting applications with systems user manager to prevent multiple processes from starting within the same cgroup.

> Be aware that if you intend to enable monitoring and actions on user.slice, user-$UID.slice, or their ancestor cgroups, it is highly recommended that your programs be managed by the systemd user manager to prevent running too many processes under the same session scope (and thus avoid a situation where memory intensive tasks trigger systemd-oomd to kill everything under the cgroup). If you're using a desktop environment like GNOME or KDE, it already spawns many session components with the systemd user manager. 

Currently applications launched by ilia inherit the cgroup of ilia, which is usually going to be `regolith-wayland.service`, `regolith-x11.service` or `user@.service` (for non systemd based sessions). As per the docs, this means, if any of the processes started by ilia are causing out-of-memory, the entire session (or user) will be killed. 

When Fedora migrated to systemd-oomd, they provided the [following recommendation](https://fedoraproject.org/wiki/Changes/EnableSystemdOomd#How_will_this_work_if_everything_is_in_the_same_cgroup?) to prevent everything from being in the same cgroup.

> ### How will this work if everything is in the same cgroup?
> 
> It will not work as systemd-oomd acts on a per-cgroup level. Applications will need to spawn processes into separate cgroups (e.g. with systemd-run) or use a desktop environment (e.g. GNOME, KDE) that does this for them.

Following this guideline, the PR will ensure that all the processes are launched in their own cgroups using `systemd-run`. 