### PR TITLE
fix: Escape unit names for systemd-run

### DIFF
--- a/src/Main.vala
+++ b/src/Main.vala
@@ -82,7 +82,18 @@ public AppInfo get_runner_app_info (AppInfo app_info) throws GLib.Error {
     string exec = app_info.get_commandline ();
     string random_suffix = Uuid.string_random ().slice (0, 8);
     string unit_name = "run_ilia_" + app_id + "_" + random_suffix + ".scope";
-    string systemd_launch = "systemd-run --user --scope --unit "+ unit_name + " " + exec;
+
+    string escaped_unit_name;
+    try {
+      string escape_launch = "systemd-escape \"" + unit_name + "\"";
+      if(!Process.spawn_command_line_sync(escape_launch, out escaped_unit_name)) {
+        escaped_unit_name = unit_name;
+      }
+    } catch (SpawnError e) {
+      escaped_unit_name = unit_name;
+    }
+
+    string systemd_launch = "systemd-run --user --scope --unit "+ escaped_unit_name + " " + exec;
     return AppInfo.create_from_commandline (systemd_launch, app_id, AppInfoCreateFlags.NONE);
 }
 


### PR DESCRIPTION
When calling systemd-run, ilia is currently using the application id as unit name and passing it directly on the command line. Some desktop shortcuts generated by programs such as Steam, will contain spaces in their application ids. This causes an issue, preventing the application to run at all. This could be fixed by enclosing the unit name within double quotes, but then you would still get a warning like this one:
`Invalid unit name "Cool Game Name" escaped as "Cool\x20Game\x20Name" (maybe you should use systemd-escape?).`

It seems like the recommended way of dealing with this is to escape those unit names with the systemd-escape command line tool, which is what I attempted to do here.

This would mean that whenever an application is launched, systemd-escape would also be launched first. Alternatively, enclosing the unit name in double-quotes would probably work for pretty much all cases, and the warning is not seen by anyone, so it might be a better way. I proposed the solution with systemd-escape only because it is what is recommended.

Note that if systemd-escape fails to launch, this would fallback to using the application id as unit name directly, as before.