### PR TITLE
Added -q option to terminal page

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -180,6 +180,7 @@ namespace Ilia {
             stdout.printf("\npages:\n");
             stdout.printf("\t'apps' - launch desktop applications (default)\n");
             stdout.printf("\t'terminal' - launch a terminal command\n");
+            stdout.printf("\t\t-q: quiet execution\n");
             stdout.printf("\t'notifications' - launch notifications manager\n");
             stdout.printf("\t'keybindings' - launch keybindings viewer\n");
             stdout.printf("\t'textlist' - select an item from a specified list\n");

--- a/src/commands/CommandPage.vala
+++ b/src/commands/CommandPage.vala
@@ -226,8 +226,8 @@ namespace Ilia {
 
             string commandline;
             if (this.quiet)
-                // if -q is given, call cmd_path through nohup and ignore output
-                commandline = "nohup " + cmd_path + " 2>&1 > /dev/null &";
+                // if -q is given, call cmd_path without opening a terminal emulator
+                commandline = cmd_path;
             else
                 // commandline = "/usr/bin/x-terminal-emulator -e \"bash -c '" + cmd_path + "; exec bash'\"";
                 // commandline = "x-terminal-emulator -e \"bash -c '" + cmd_path + "'\"";

--- a/src/commands/CommandPage.vala
+++ b/src/commands/CommandPage.vala
@@ -25,6 +25,8 @@ namespace Ilia {
 
         private Gtk.TreePath path;
 
+        private bool quiet = false;
+
         public string get_name() {
             return "<u>C</u>ommands";
         }
@@ -52,6 +54,9 @@ namespace Ilia {
         public async void initialize(GLib.Settings settings, HashTable<string, string ?> arg_map, Gtk.Entry entry, SessionContoller sessionController, string wm_name, bool is_wayland) throws GLib.Error {
             this.entry = entry;
             this.session_controller = sessionController;
+
+            if (arg_map.contains("-q"))
+                this.quiet = true;
 
             model = new Gtk.ListStore(ITEM_VIEW_COLUMNS, typeof (string), typeof (string));
 
@@ -219,9 +224,14 @@ namespace Ilia {
             // TODO ~ Enable two launch modes with some modifier.  By default terminal exits when program exits.
             // todo is to add another mode in which the terminal does not exit after program completes.
 
-            // string commandline = "/usr/bin/x-terminal-emulator -e \"bash -c '" + cmd_path + "; exec bash'\"";
-            // string commandline = "x-terminal-emulator -e \"bash -c '" + cmd_path + "'\"";
-            string commandline = "x-terminal-emulator -e '" + cmd_path + "'";
+            string commandline;
+            if (this.quiet)
+                // if -q is given, call cmd_path through bash and ignore output
+                commandline = "bash -c '" + cmd_path + " > /dev/null 2>&1'";
+            else
+                // commandline = "/usr/bin/x-terminal-emulator -e \"bash -c '" + cmd_path + "; exec bash'\"";
+                // commandline = "x-terminal-emulator -e \"bash -c '" + cmd_path + "'\"";
+                commandline = "x-terminal-emulator -e '" + cmd_path + "'";
 
             // stdout.printf("%s\n", commandline);
 

--- a/src/commands/CommandPage.vala
+++ b/src/commands/CommandPage.vala
@@ -226,8 +226,8 @@ namespace Ilia {
 
             string commandline;
             if (this.quiet)
-                // if -q is given, call cmd_path through bash and ignore output
-                commandline = "bash -c '" + cmd_path + " > /dev/null 2>&1'";
+                // if -q is given, call cmd_path through nohup and ignore output
+                commandline = "nohup " + cmd_path + " 2>&1 > /dev/null &";
             else
                 // commandline = "/usr/bin/x-terminal-emulator -e \"bash -c '" + cmd_path + "; exec bash'\"";
                 // commandline = "x-terminal-emulator -e \"bash -c '" + cmd_path + "'\"";


### PR DESCRIPTION
This change addresses issue #70 by adding a `-q` option for the terminal page. When running `ilia -p terminal -q`, the selected command is executed, but no `x-terminal-emulator` is opened, and the output is discarded.

This mirrors the default behavior in i3 when executing commands via d-menu. It's useful in scenarios where the command's output isn't needed, and only its side effects are of interest.