### PR TITLE
Improves clipboard support

### DIFF
--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -116,15 +116,6 @@ namespace Ilia {
                         change_size(-128);
                         return true;
                     }
-                } else if ((key.state & Gdk.ModifierType.CONTROL_MASK) == Gdk.ModifierType.CONTROL_MASK) {
-                    if (key.keyval == 'c') { // Expand dialog
-                        clipboard_copy ();
-                        return true;
-                    }
-                    if (key.keyval == 'v') {
-                        clipboard_paste ();
-                        return true;
-                    }
                 }
 
                 bool key_handled = false;
@@ -151,7 +142,7 @@ namespace Ilia {
                             break;
                         case KEY_CODE_RIGHT:
                         case KEY_CODE_LEFT: // Switch pages
-                            notebook.grab_focus ();
+                            if(!entry.has_focus) notebook.grab_focus ();
                             break;
                         default:            // Pass key event to active page for handling
                             // stdout.printf ("Keycode: %u\n", key.keyval);
@@ -409,26 +400,6 @@ namespace Ilia {
 
         void on_entry_activated() {
             dialog_pages[active_page].on_entry_activated ();
-        }
-
-        void clipboard_copy() {
-            var display = this.get_screen ().get_display ();
-            var clipboard = Clipboard.get_for_display(display, Gdk.SELECTION_CLIPBOARD);
-
-            clipboard.set_text(entry.get_text (), entry.get_text ().length);
-            clipboard.store ();
-        }
-
-        void clipboard_paste() {
-            var display = this.get_screen ().get_display ();
-            var clipboard = Clipboard.get_for_display(display, Gdk.SELECTION_CLIPBOARD);
-
-            string text = clipboard.wait_for_text ();
-
-            if (text != null) {
-                int pos = entry.cursor_position;
-                entry.get_buffer ().insert_text(pos, text.data);
-            }
         }
 
         public void quit() {

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -16,6 +16,8 @@ namespace Ilia {
                 path.next ();
                 item_view.get_selection ().select_path(path);
                 item_view.set_cursor(path, null, false);
+            } else {
+		return false;
             }
 
             return true;


### PR DESCRIPTION
# Improved clipboard support
Implements changes to pass all Ctr  related key events directly to GtkEntry (InputBox) which enables all `Ctrl A`, `Ctrl X`, and all Ctrl input modifiers which are by default implemented for GtkEntry object


### Improved Clipboard Support

All `Ctrl`-related key events are directly passed to the `GtkEntry` (InputBox) widget. This allows default `GtkEntry` behaviors, such as `Ctrl+A` (select all), `Ctrl+X` (cut), `Ctrl+C` (copy), and `Ctrl+V` (paste), to work

#### Key Changes:
1. **Direct Key Event Forwarding:** All `Ctrl` key events are now directly passed to `GtkEntry`.
2. **Improved Compatibility:** Default `GtkEntry` behaviors are preserved without requiring custom handling for standard clipboard shortcuts.
3. **Ignore arrow key presses when search bar is highlighted:** makes it consistent with other search boxes and allows for better navigation for editing text in the input

Related: #69

first time contributing to the project, feedback is appreciated!