### PR TITLE
nix flake with packaging for ilia

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1740126099,
+        "narHash": "sha256-ozoOtE2hGsqh4XkTJFsrTkNxkRgShxpQxDynaPZUGxk=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "32fb99ba93fea2798be0e997ea331dd78167f814",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "systems": "systems"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,26 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    systems.url = "github:nix-systems/default";
+  };
+
+  outputs = { self, nixpkgs, systems }:
+    let
+      perSystem = callback: nixpkgs.lib.genAttrs (import systems) (system: callback (initPkgs system));
+      initPkgs = system: nixpkgs.legacyPackages.${system};
+    in
+    {
+      packages = perSystem (pkgs: rec {
+        # Run ilia in the project repo with:
+        #
+        #     $ nix run
+        #
+        # or run without cloning the repo with:
+        #
+        #     $ nix run github:regolith-linux/ilia
+        #
+        default = ilia;
+        ilia = pkgs.callPackage ./nix/ilia.nix { source = ./.; };
+      });
+    };
+}

--- a/nix/ilia.nix
+++ b/nix/ilia.nix
@@ -3,7 +3,6 @@
   # callPackage automatically populates all of these arguments from nixpkgs
 , atk
 , cairo
-, gobject-introspection
 , gtk3
 , gtk-layer-shell
 , json-glib
@@ -36,7 +35,6 @@ stdenv.mkDerivation {
   buildInputs = [
     atk
     cairo
-    gobject-introspection # avoids error, "Package Gtk-3.0 not found in Vala API directories or Ggobject-introspection GIR directories"
     gtk3
     gtk-layer-shell
     json-glib

--- a/nix/ilia.nix
+++ b/nix/ilia.nix
@@ -1,0 +1,51 @@
+{ source # source must be given explicitly when calling callPackage
+
+  # callPackage automatically populates all of these arguments from nixpkgs
+, atk
+, cairo
+, gobject-introspection
+, gtk3
+, gtk-layer-shell
+, json-glib
+, lib
+, libgee
+, meson
+, ninja
+, pkg-config
+, stdenv
+, tinysparql
+, uncrustify
+, vala
+, wrapGAppsHook3
+}:
+
+stdenv.mkDerivation {
+  name = "ilia";
+  src = source;
+  postPatch = ''
+    patchShebangs meson_scripts
+  '';
+  nativeBuildInputs = [
+    meson
+    ninja
+    pkg-config
+    uncrustify
+    vala
+    wrapGAppsHook3 # wraps the executable to register gsettings-schemas files
+  ];
+  buildInputs = [
+    atk
+    cairo
+    gobject-introspection # avoids error, "Package Gtk-3.0 not found in Vala API directories or Ggobject-introspection GIR directories"
+    gtk3
+    gtk-layer-shell
+    json-glib
+    libgee
+    tinysparql
+  ];
+  meta = {
+    homepage = "https://github.com/regolith-linux/ilia?tab=readme-ov-file";
+    license = [ lib.licenses.asl20 ];
+  };
+}
+


### PR DESCRIPTION
Hi! I was trying out Ilia, and I wound up writing Nix packaging for it. I thought I would share in case you want to use it, or perhaps just so that anyone searching for a Nix package for Ilia can reference this PR.

This PR adds a "flake" to the repo which makes it easy for Nix users to install Ilia. Adding a flake to the repo lets users automatically track the latest Ilia version. But with a slight modification you can get a standalone Nix expression locked to a specific repo revision that can be submitted to the nixpkgs repo. That looks like this:

```nix
{ atk
, cairo
, fetchFromGitHub
, gobject-introspection
, gtk3
, gtk-layer-shell
, json-glib
, lib
, libgee
, meson
, ninja
, pkg-config
, stdenv
, tinysparql
, uncrustify
, vala
, wrapGAppsHook3
}:

stdenv.mkDerivation rec {
  pname = "ilia";
  version = "0.15.1";
  src = fetchFromGitHub {
    owner = "regolith-linux";
    repo = "ilia";
    rev = "v${version}";
    hash = "sha256-E6I8NpIhzhmXj8AoX2tsiAl4pyuOyc+4+U6TOaSrBVA=";
  };
  postPatch = ''
    patchShebangs meson_scripts
  '';
  nativeBuildInputs = [
    meson
    ninja
    pkg-config
    uncrustify
    vala
    wrapGAppsHook3 # wraps the executable to register gsettings-schemas files
  ];
  buildInputs = [
    atk
    cairo
    gobject-introspection # avoids error, "Package Gtk-3.0 not found in Vala API directories or Ggobject-introspection GIR directories"
    gtk3
    gtk-layer-shell
    json-glib
    libgee
    tinysparql
  ];
  meta = {
    homepage = "https://github.com/regolith-linux/ilia?tab=readme-ov-file";
    license = [ lib.licenses.asl20 ];
  };
}
```

As you can see another advantage of a Nix package is that it provides executable documentation of all of the required build and runtime dependencies. Build dependencies are listed in `nativeBuildInputs`, and runtime dependencies are listed in `buildInputs`.