### PR TITLE
Update deprecated meson.source_root and enhance searchBox functionality

### DIFF
--- a/src/Util.vala
+++ b/src/Util.vala
@@ -12,13 +12,13 @@ namespace Ilia {
                 path.prev ();
                 item_view.get_selection ().select_path(path);
                 item_view.set_cursor(path, null, false);
+                return true;
             } else if ((key.keyval == 'n' || key.keyval == 'j') && !is_last) {
                 path.next ();
                 item_view.get_selection ().select_path(path);
                 item_view.set_cursor(path, null, false);
+                return true;
             }
-
-            return true;
         }
 
         return false;

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,7 +5,7 @@ cfg_ilia.set('GETTEXT_PACKAGE', 'ilia')
 cfg_ilia.set('RELEASE_NAME', 'ilia')
 cfg_ilia.set('PREFIX', get_option('prefix'))
 cfg_ilia.set('VERSION', '0.12')
-cfg_ilia.set('TESTSRCDIR', meson.source_root())
+cfg_ilia.set('TESTSRCDIR', meson.project_source_root())
 
 cfgfile_1 = configure_file(
 	input: 'Config.vala.base',


### PR DESCRIPTION
Replace deprecated `meson.source_root` with `meson.project_source_root` and improve the searchBox by adding vim-style navigation and clipboard operations.