### PR TITLE
fix: modified ctrl-v past behavior

### DIFF
--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -496,10 +496,8 @@ namespace Ilia {
                 
                 if (entry.get_selection_bounds(out start, out end)) {
                     entry.get_buffer().delete_text(start, end - start);
-                    entry.insert_at_cursor(text);
-                } else {
-                    entry.insert_at_cursor(text);
                 }
+                entry.insert_at_cursor(text);
             }
         }
         

--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -496,10 +496,9 @@ namespace Ilia {
                 
                 if (entry.get_selection_bounds(out start, out end)) {
                     entry.get_buffer().delete_text(start, end - start);
-                    entry.get_buffer().insert_text(start, text.data);
+                    entry.insert_at_cursor(text);
                 } else {
-                    int pos = entry.cursor_position;
-                    entry.get_buffer().insert_text(pos, text.data);
+                    entry.insert_at_cursor(text);
                 }
             }
         }


### PR DESCRIPTION
Updates the ctrl-v paste behavior 

## Before
Ctrl -v added text after cursor, keeping cursor where it was 

https://github.com/user-attachments/assets/ddbbe62a-0cf5-4208-ab50-ea8b837468fd

## Now
Ctrl -v adds text before the cursor, moving cursor forward

https://github.com/user-attachments/assets/6151d662-a4c0-428a-bb8e-e6b3709fff44


as discussed in #97 