### PR TITLE
Removed newlines in debug() statements

### DIFF
--- a/src/keybindings/I3Ipc.vala
+++ b/src/keybindings/I3Ipc.vala
@@ -303,12 +303,12 @@ namespace Ilia {
         private Json.Node ? wm_ipc(WM_COMMAND command) throws GLib.Error {
             ssize_t sent = socket.send(generate_request(command));
 
-            debug("Sent " + sent.to_string () + " bytes to " + wm_name + ".\n");
+            debug("Sent " + sent.to_string () + " bytes to " + wm_name);
             uint8[] buffer = new uint8[buffer_size];
 
             ssize_t len = socket.receive(buffer);
 
-            debug("Received  " + len.to_string () + " bytes from " + wm_name + ".\n");
+            debug("Received  " + len.to_string () + " bytes from " + wm_name);
 
             Bytes responseBytes = new Bytes.take(buffer[0 : len]);
 

--- a/src/notifications/RoficationClient.vala
+++ b/src/notifications/RoficationClient.vala
@@ -39,7 +39,7 @@ namespace Ilia {
             var socket = open_socket(socket_addr);
 
             ssize_t sent = socket.send("list\n".data);
-            debug("Sent " + sent.to_string () + " bytes to notification backend.\n");
+            debug("Sent " + sent.to_string () + " bytes to notification backend.");
 
             var str_builder = new StringBuilder ();
             uint8[] buffer = new uint8[buffer_size];
@@ -47,7 +47,7 @@ namespace Ilia {
 
             do {
                 len = socket.receive_with_blocking(buffer, true);
-                debug("Received  " + len.to_string () + " bytes from notification backend.\n");
+                debug("Received  " + len.to_string () + " bytes from notification backend.");
                 if (len > 0)str_builder.append_len((string) buffer, len);
             } while (len > 0);
 
@@ -79,7 +79,7 @@ namespace Ilia {
 
             ssize_t sent = socket.send(message.data);
 
-            debug("Sent " + sent.to_string () + " bytes to notification backend.\n");
+            debug("Sent " + sent.to_string () + " bytes to notification backend.");
             socket.close ();
         }
 
@@ -100,7 +100,7 @@ namespace Ilia {
 
             ssize_t sent = socket.send(cmd.data);
 
-            debug("Sent " + sent.to_string () + " bytes to notification backend.\n");
+            debug("Sent " + sent.to_string () + " bytes to notification backend.");
             socket.close ();
         }
 
@@ -108,7 +108,7 @@ namespace Ilia {
             var socket = open_socket(socket_addr);
             ssize_t sent = socket.send(("dela:" + app + "\n").data);
 
-            debug("Sent " + sent.to_string () + " bytes to notification backend.\n");
+            debug("Sent " + sent.to_string () + " bytes to notification backend.");
             socket.close ();
         }
 


### PR DESCRIPTION
I'm not exactly sure why we do the newlines, I think we don't need to.

Removes whitespace noise in debug logs like this:
```
** (ilia:75201): DEBUG: 10:40:35.139: RoficationClient.vala:42: Sent 5 bytes to notification backend.

** (ilia:75201): DEBUG: 10:40:35.145: RoficationClient.vala:50: Received  8192 bytes from notification backend.

** (ilia:75201): DEBUG: 10:40:35.145: RoficationClient.vala:50: Received  4036 bytes from notification backend.

** (ilia:75201): DEBUG: 10:40:35.145: RoficationClient.vala:50: Received  0 bytes from notification backend.

```