### PR TITLE
Fix prefix matching sort.

### DIFF
--- a/src/Util.vala
+++ b/src/Util.vala
@@ -128,12 +128,13 @@ namespace Ilia {
             var app_b_has_prefix = app_b_name.has_prefix(query_string);
 
             if (query_string.length > 1 && (app_a_has_prefix || app_b_has_prefix)) {
-                if (app_b_has_prefix && !app_b_has_prefix)
-                    // stdout.printf ("boosted %s for %s\n", app_a.get_name (), query_string);
-                    return -1;
-                else if (!app_a_has_prefix && app_b_has_prefix)
+                if (app_b_has_prefix && !app_a_has_prefix) {
                     // stdout.printf ("boosted %s for %s\n", app_b.get_name (), query_string);
                     return 1;
+                } else if (app_a_has_prefix && !app_b_has_prefix) {
+                    // stdout.printf ("boosted %s for %s\n", app_a.get_name (), query_string);
+                    return -1;
+                }
             }
         }
 
@@ -146,11 +147,16 @@ namespace Ilia {
                 return -1;
             else if (a_count < b_count)
                 return 1;
-            else
-                return 0;
+            // If launch counts are equal, fall through to alphabetical ordering
         }
 
         // Third priority: alphabetical order
-        return app_a_name.ascii_casecmp(app_b_name);
+        int compare_result = app_a_name.ascii_casecmp(app_b_name);
+        if (compare_result < 0)
+            return -1;
+        else if (compare_result > 0)
+            return 1;
+        else
+            return 0;
     }
 }

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -97,4 +97,60 @@ namespace Ilia {
 
         return escaped.str.replace("/", "-");
     }
+
+    /**
+     * Compare two desktop applications for sorting purposes
+     *
+     * This function implements the core logic for sorting desktop applications based on:
+     * 1. Prefix matching with a query string (if provided)
+     * 2. Launch counts (popularity)
+     * 3. Alphabetical order as a fallback
+     *
+     * @param app_a_name The lowercase name of the first application
+     * @param app_b_name The lowercase name of the second application
+     * @param app_a_id The ID of the first application
+     * @param app_b_id The ID of the second application
+     * @param query_string The lowercase query string to match against (can be empty)
+     * @param launch_counts A hash table mapping app IDs to launch counts
+     * @return -1 if app_a should come before app_b, 1 if app_b should come before app_a, 0 if equal
+     */
+    public static int compare_desktop_apps(
+        string app_a_name,
+        string app_b_name,
+        string app_a_id,
+        string app_b_id,
+        string query_string,
+        HashTable<string, int> launch_counts
+    ) {
+        // First priority: prefix matching with query string
+        if (query_string.length > 0) {
+            var app_a_has_prefix = app_a_name.has_prefix(query_string);
+            var app_b_has_prefix = app_b_name.has_prefix(query_string);
+
+            if (query_string.length > 1 && (app_a_has_prefix || app_b_has_prefix)) {
+                if (app_b_has_prefix && !app_b_has_prefix)
+                    // stdout.printf ("boosted %s for %s\n", app_a.get_name (), query_string);
+                    return -1;
+                else if (!app_a_has_prefix && app_b_has_prefix)
+                    // stdout.printf ("boosted %s for %s\n", app_b.get_name (), query_string);
+                    return 1;
+            }
+        }
+
+        // Second priority: launch counts (popularity)
+        var a_count = launch_counts.get(app_a_id);
+        var b_count = launch_counts.get(app_b_id);
+
+        if (a_count > 0 || b_count > 0) {
+            if (a_count > b_count)
+                return -1;
+            else if (a_count < b_count)
+                return 1;
+            else
+                return 0;
+        }
+
+        // Third priority: alphabetical order
+        return app_a_name.ascii_casecmp(app_b_name);
+    }
 }

--- a/src/apps/DesktopAppPage.vala
+++ b/src/apps/DesktopAppPage.vala
@@ -181,43 +181,34 @@ namespace Ilia {
                 execute_app(iter);
         }
 
+        /**
+         * Sort function for the application list
+         *
+         * This is a wrapper around the testable compare_desktop_apps utility function
+         * that extracts the necessary data from the TreeModel and TreeIter objects
+         */
         private int app_sort_func(TreeModel model, TreeIter a, TreeIter b) {
-            string query_string = entry.get_text ().down ();
+            string query_string = entry.get_text().down();
+
             DesktopAppInfo app_a;
             model.@get(a, ITEM_VIEW_COLUMN_APPINFO, out app_a);
             DesktopAppInfo app_b;
             model.@get(b, ITEM_VIEW_COLUMN_APPINFO, out app_b);
 
-            var app_a_name = app_a.get_name ().down ();
-            var app_b_name = app_b.get_name ().down ();
+            var app_a_name = app_a.get_name().down();
+            var app_b_name = app_b.get_name().down();
 
-            if (query_string.length > 0) {
-                var app_a_has_prefix = app_a_name.has_prefix(query_string);
-                var app_b_has_prefix = app_b_name.has_prefix(query_string);
+            var app_a_id = app_a.get_id();
+            var app_b_id = app_b.get_id();
 
-                if (query_string.length > 1 && (app_a_has_prefix || app_b_has_prefix)) {
-                    if (app_b_has_prefix && !app_b_has_prefix)
-                        // stdout.printf ("boosted %s for %s\n", app_a.get_name (), query_string);
-                        return -1;
-                    else if (!app_a_has_prefix && app_b_has_prefix)
-                        // stdout.printf ("boosted %s for %s\n", app_b.get_name (), query_string);
-                        return 1;
-                }
-            }
-
-            var a_count = launch_counts.get(app_a.get_id ());
-            var b_count = launch_counts.get(app_b.get_id ());
-
-            if (a_count > 0 || b_count > 0) {
-                if (a_count > b_count)
-                    return -1;
-                else if (a_count < b_count)
-                    return 1;
-                else
-                    return 0;
-            }
-
-            return app_a_name.ascii_casecmp(app_b_name);
+            return compare_desktop_apps(
+                app_a_name,
+                app_b_name,
+                app_a_id,
+                app_b_id,
+                query_string,
+                launch_counts
+            );
         }
 
         private HashTable<string, int> load_launch_counts(string[] history) {

--- a/test/UtilTest.vala
+++ b/test/UtilTest.vala
@@ -15,14 +15,39 @@ public void test_systemd_escape () {
      assert (Ilia.systemd_escape(".@/foo$bAR§qux/ab.çd-êf_gh=ij") == "\\x2e\\x40-foo\\x24bAR\\xc2\\xa7qux-ab.\\xc3\\xa7d\\x2d\\xc3\\xaaf_gh\\x3dij");
 }
 
-// correct
-// -dev-disk-by\\x2dlabel-ab.cd\\x2def_gh\\x3dij
-// -dev-disk-by\\x2dlabel-ab.cd\\x2def\x5fgh\x3dij
-// actual
+public void test_compare_desktop_apps() {
+    // Create a mock launch counts table
+    var launch_counts = new GLib.HashTable<string, int>(GLib.str_hash, GLib.str_equal);
+    launch_counts.insert("app1.desktop", 5);
+    launch_counts.insert("app2.desktop", 10);
+    launch_counts.insert("app3.desktop", 5);
+
+    // Test: Prefix matching (query string "fi")
+    // app1 = "firefox", app2 = "files"
+    // Both have prefix "fi", so should fall back to launch counts
+    assert(Ilia.compare_desktop_apps(
+        "firefox", "files",
+        "app1.desktop", "app2.desktop",
+        "fi", launch_counts) == 1); // app2 has higher launch count
+
+    // Test: No query string, different launch counts
+    assert(Ilia.compare_desktop_apps(
+        "app1", "app2",
+        "app1.desktop", "app2.desktop",
+        "", launch_counts) == 1); // app2 has higher launch count
+
+    // Test: No query string, no launch counts
+    assert(Ilia.compare_desktop_apps(
+        "app4", "app5",
+        "app4.desktop", "app5.desktop",
+        "", new GLib.HashTable<string, int>(GLib.str_hash, GLib.str_equal)) == -1); // alphabetical order
+}
 
 public int main (string[] args) {
     Test.init (ref args);
 
     Test.add_func ("/test_systemd_escape", test_systemd_escape);
+    Test.add_func ("/test_compare_desktop_apps", test_compare_desktop_apps);
+
     return Test.run ();
 }

--- a/test/UtilTest.vala
+++ b/test/UtilTest.vala
@@ -41,6 +41,18 @@ public void test_compare_desktop_apps() {
         "app4", "app5",
         "app4.desktop", "app5.desktop",
         "", new GLib.HashTable<string, int>(GLib.str_hash, GLib.str_equal)) == -1); // alphabetical order
+
+    // Test: One app has prefix, other doesn't
+    assert(Ilia.compare_desktop_apps(
+        "firefox", "chrome",
+        "app1.desktop", "app3.desktop",
+        "fi", launch_counts) == -1); // firefox has prefix "fi"
+
+    // Test: Equal launch counts, fall back to alphabetical
+    assert(Ilia.compare_desktop_apps(
+        "chrome", "firefox",
+        "app1.desktop", "app3.desktop",
+        "", launch_counts) == -1); // "chrome" comes before "firefox" alphabetically
 }
 
 public int main (string[] args) {


### PR DESCRIPTION
This is in 2 commits. The first commit is a refactor of the sort function into Utils to make it testable, then I added tests to verify the existing behavior.

Second commit is fixing the prefix sort order and adding new tests against that case.

----

Previously compare_desktop_apps was not comparing app prefixes
correctly, meaning if a user (me!) typed in `files`, even though
literally the name == files, it didn't show up at the top.

This fixes that logic error.

Additionally it actually activates the fallback sort behavior when there
are equal app launch counts by normalizing the alphabetical sort.

Also test cases are added.

Fixes #26.