### PR TITLE
Added debug instructions and timers

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,11 +77,34 @@ src/ilia
 
 ## Lint
 
-### Uncrustify
+In a build dir run this to execute `uncrustify`:
 
-```shell
-ninja fixstyle
-```
+    ninja fixstyle
+
+## Test
+
+Run the unit tests in a build dir with:
+
+    ninja test
+
+For manual testing, it is useful to run with throttled CPU in debug mode, run ilia like this:
+
+    systemd-run --pipe --user --property=CPUQuota=10% --property=MemoryLimit=100M --property=MemorySwapMax=0 --property=RuntimeMaxSec=30 --collect --wait -E G_MESSAGES_DEBUG=all build/src/ilia -p apps
+
+Otherwise, you won't be able to see the effects of any async issues, which only reveal themselves under heavy load.
+
+You can always run `ilia` in debug mode by editing `~/.config/regolith3/Xresources`
+
+    # In ~/.config/regolith3/Xresources
+    # Make this file if it doesn't exist.
+    # Use MOD + shift + r to reload Regolith to pick up the change
+    wm.program.launcher.app: G_MESSAGES_DEBUG=all ilia -p apps
+
+And then use:
+
+    journalctl --user --follow | grep ilia
+
+To see any debug messages from your session.
 
 ## Package
 

--- a/src/apps/DesktopAppPage.vala
+++ b/src/apps/DesktopAppPage.vala
@@ -2,6 +2,7 @@ using Gtk;
 
 namespace Ilia {
     class DesktopAppPage : DialogPage, GLib.Object {
+        private static GLib.Timer app_timer;
         private const int ITEM_VIEW_COLUMNS = 4;
         private const int ITEM_VIEW_COLUMN_ICON = 0;
         private const int ITEM_VIEW_COLUMN_NAME = 1;
@@ -71,6 +72,8 @@ namespace Ilia {
         }
 
         public async void initialize(GLib.Settings settings, HashTable<string, string ?> arg_map, Gtk.Entry entry, SessionContoller sessionController, string wm_name, bool is_wayland) throws GLib.Error {
+            app_timer = new GLib.Timer();
+            app_timer.start();
             this.settings = settings;
             this.entry = entry;
             this.session_controller = sessionController;
@@ -133,7 +136,7 @@ namespace Ilia {
 
         public void show() {
             item_view.grab_focus ();
-            debug("DesktopAppPage ready to accept keystrokes");
+            debug("DesktopAppPage ready to accept keystrokes (%.3f seconds since app start)", app_timer.elapsed());
         }
 
         // Initialize the view displaying selections
@@ -254,7 +257,6 @@ namespace Ilia {
         }
 
         private void load_apps() {
-            // var start_time = get_monotonic_time();
             // determine theme for icons
             icon_theme = Gtk.IconTheme.get_default ();
             // Set a blank icon to avoid visual jank as real icons are loaded
@@ -264,7 +266,7 @@ namespace Ilia {
             foreach (AppInfo appinfo in app_list) {
                 read_desktop_file(appinfo, blank_icon);
             }
-            // stdout.printf("time cost: %" + int64.FORMAT + "\n", (get_monotonic_time() - start_time));
+            debug("Finished loading all apps (%.3f seconds since app start)", app_timer.elapsed());
         }
 
         private void read_desktop_file(AppInfo appInfo, Gdk.Pixbuf ? icon_img) {
@@ -340,6 +342,7 @@ namespace Ilia {
                     });
                 }
             }
+            debug("Finished loading all icons (%.3f seconds since app start)", app_timer.elapsed());
         }
 
         // In the case that neither success or failure signals are received, exit after a timeout


### PR DESCRIPTION
This adds an app timer so we can consistently see how fast/slow things are. It replaces the commented out timer that was there previously.

I also added README instructions on how to test/debug.