### PR TITLE
Default to using release build types

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ ninja
 src/ilia
 ```
 
+By default, Ilia builds with release optimizations. For debug builds:
+
+```shell
+meson setup builddebug --buildtype=debug
+ninja -C builddebug
+```
+
 ## Lint
 
 ### Uncrustify

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,10 @@
 project('ilia',
   ['c','vala'],
-  version: '0.12')
+  version: '0.12',
+  default_options: [
+    'buildtype=release',
+    'b_ndebug=if-release'
+  ])
 
 add_global_arguments('-DGETTEXT_PACKAGE="ilia"',language: 'c')
 


### PR DESCRIPTION
This changes the default build type to be "release" https://mesonbuild.com/Builtin-options.html#details-for-buildtype

This optimizes the build and removes debug symbols.

I don't see a speed difference with my timers, but we probably have more work to do there. The build is 65% smaller.

I also added docs for how to make a debug build for real debugging. We can also use the `#if !NDBUG` macro (meson adds that for free?) for any code we want to gate on a debug build.