### PR TITLE
Clean up leftover prints from debugging

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -85,7 +85,7 @@ namespace Ilia {
                 Gdk.Window gdkwin = window.get_window();
                 var seat = grab_inputs(gdkwin);
                 if (seat == null) {
-                    stderr.printf("Failed to aquire access to input devices, aborting.");
+                    stderr.printf("Failed to acquire access to input devices, aborting.");
                     Process.exit(1);
                 }
                 window.set_seat(seat);

--- a/src/DialogWindow.vala
+++ b/src/DialogWindow.vala
@@ -199,7 +199,6 @@ namespace Ilia {
                             notebook.grab_focus();
                             break;
                         default:            // Pass key event to active page for handling
-                            // stdout.printf ("Keycode: %u\n", key.keyval);
                             key_handled = dialog_pages[active_page].key_event(key);
                             if (!key_handled)
                                 entry.grab_focus_without_selecting();  // causes entry to consume all unhandled key events

--- a/src/Util.vala
+++ b/src/Util.vala
@@ -49,8 +49,6 @@ namespace Ilia {
         if (systemd_run_path == null)
             return app_info;
         string app_id = app_info.get_id();
-        stdout.printf("KG2: \nbefore: '%s'\nafter : '%s'\n", app_id, systemd_escape(app_id));
-        stdout.flush();
         string exec = app_info.get_commandline();
         string random_suffix = Uuid.string_random().slice(0, 8);
         string unit_name = "run_ilia_" + systemd_escape(app_id) + "_" + random_suffix + ".scope";
@@ -125,10 +123,8 @@ namespace Ilia {
 
             if (query_string.length > 1 && (app_a_has_prefix || app_b_has_prefix)) {
                 if (app_b_has_prefix && !app_a_has_prefix)
-                    // stdout.printf ("boosted %s for %s\n", app_b.get_name (), query_string);
                     return 1;
                 else if (app_a_has_prefix && !app_b_has_prefix)
-                    // stdout.printf ("boosted %s for %s\n", app_a.get_name (), query_string);
                     return -1;
             }
         }

--- a/src/apps/DesktopAppPage.vala
+++ b/src/apps/DesktopAppPage.vala
@@ -226,11 +226,6 @@ namespace Ilia {
                     table.insert(app_name, 1);
             }
 
-            /*
-               table.foreach ((key, val) => {
-                print ("%s => %d\n", key, val);
-               });
-             */
 
             return table;
         }

--- a/src/commands/CommandPage.vala
+++ b/src/commands/CommandPage.vala
@@ -232,7 +232,6 @@ namespace Ilia {
                 // commandline = "x-terminal-emulator -e \"bash -c '" + cmd_path + "'\"";
                 commandline = "x-terminal-emulator -e '" + cmd_path + "'";
 
-            // stdout.printf("%s\n", commandline);
 
             try {
                 var app_info = AppInfo.create_from_commandline(commandline, null, GLib.AppInfoCreateFlags.NONE);

--- a/src/keybindings/ConfigParser.vala
+++ b/src/keybindings/ConfigParser.vala
@@ -54,7 +54,6 @@ public class ConfigParser {
                 last_keybinding = parseLine(trimmedLine, config_map);
             } else if (execMatch(trimmedLine) && last_keybinding != null) {
                 last_keybinding.exec = parseExecLine(trimmedLine, variableMap);
-                // stdout.printf("got %s\n", last_keybinding.exec);
                 last_keybinding = null;
             } else if (setFromResourceMatch(trimmedLine)) {
                 parseSetFromResourceLine(trimmedLine, variableMap);
@@ -142,15 +141,4 @@ public class ConfigParser {
 
         return binding;
     }
-
-    /*
-       private void debugConfigMap(Map<string, ArrayList<Keybinding>> configMap) {
-       foreach (var entry in config_map.entries) {
-        stdout.printf ("%s =>\n", entry.key);
-        foreach (Keybinding k in entry.value) {
-          stdout.printf ("      %s %s\n", k.label, k.spec);
-        }
-       }
-       }
-     */
 }

--- a/src/notifications/RoficationClient.vala
+++ b/src/notifications/RoficationClient.vala
@@ -55,7 +55,6 @@ namespace Ilia {
 
             socket.close();
 
-            // stdout.printf("%s\n", payload);
 
             Json.Parser parser = new Json.Parser();
             parser.load_from_data(payload);

--- a/src/windows/WindowPage.vala
+++ b/src/windows/WindowPage.vala
@@ -256,7 +256,6 @@ namespace Ilia {
             }
 
             string commandline = cli_bin + exec;
-            // stdout.printf("running %s\n", commandline);
 
             try {
                 var app_info = AppInfo.create_from_commandline(commandline, null, AppInfoCreateFlags.NONE);


### PR DESCRIPTION
We have the `debug()` macro and better tools now.

This PR cleans out leftovers. If you want I can add any of these back in gated on if it is a debug build or not. Or just start fresh?